### PR TITLE
Create stage one finance app shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+node_modules
+.dist
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+package-lock.json
+.idea
+.vscode
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,45 @@
-# sleekfinance
-sleek modern finance tracker
+# SleekFinance
+
+SleekFinance is a dark-themed personal finance and budgeting workspace. Stage 1 provides an interactive shell with navigation, placeholder content for each upcoming module, and a simple sign-in experience.
+
+## Quickstart
+
+The app ships with a one-command launcher that installs dependencies (if needed) and boots the Vite dev server.
+
+```bash
+./start.sh
+```
+
+Once the server is running, open the provided URL in your browser (defaults to `http://localhost:5173`). Use any email and password to sign in and explore the application shell.
+
+## Available Scripts
+
+| Command | Description |
+| --- | --- |
+| `./start.sh` | Installs dependencies on first run and starts the Vite development server. |
+| `npm run dev` | Starts the Vite development server without installing dependencies. |
+| `npm run build` | Type-checks and bundles the production build. |
+| `npm run preview` | Serves the production build locally after running `npm run build`. |
+
+## Project Structure
+
+```
+├── index.html              # Vite entry point
+├── src
+│   ├── App.tsx             # App routing and authentication gate
+│   ├── main.tsx            # React bootstrap
+│   ├── auth/               # Simple auth context
+│   ├── components/         # Reusable UI elements (layout, tooltips, headers)
+│   ├── pages/              # Placeholder content for each navigation section
+│   └── styles/             # Global and component-scoped styles
+├── start.sh                # One-command launcher
+└── README.md
+```
+
+## Accessibility & Theming
+
+The shell uses a high-contrast dark palette with orange/yellow accents. Tooltips are placed throughout the experience as placeholders for future contextual help. Layouts are responsive down to tablet sizes, and core navigation is keyboard accessible via focus styles supplied by the browser.
+
+## Next Steps
+
+Future stages will wire up data models, rule engines, import pipelines, analytics dashboards, and investment tracking based on the placeholders introduced here.

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffb347" />
+      <stop offset="100%" stop-color="#ffcc33" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="12" fill="#1c1c1f" />
+  <path d="M16 44 L32 16 L48 44 Z" fill="url(#g)" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SleekFinance</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "sleekfinance",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "lint": "echo 'No linting configured'",
+    "start": "vite",
+    "setup": "npm install",
+    "start:full": "npm run setup && npm run dev"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.46",
+    "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
+    "typescript": "^5.3.3",
+    "vite": "^5.1.6"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,50 @@
+import { Navigate, Route, Routes } from 'react-router-dom';
+import { AuthProvider, useAuth } from './auth/AuthContext';
+import Layout from './components/Layout';
+import Overview from './pages/Overview';
+import Transactions from './pages/Transactions';
+import Accounts from './pages/Accounts';
+import Pots from './pages/Pots';
+import Budgets from './pages/Budgets';
+import Rules from './pages/Rules';
+import Reports from './pages/Reports';
+import Investments from './pages/Investments';
+import Imports from './pages/Imports';
+import Settings from './pages/Settings';
+import Help from './pages/Help';
+import Login from './pages/Login';
+
+const AppShell = () => {
+  const { isAuthenticated } = useAuth();
+
+  if (!isAuthenticated) {
+    return <Login />;
+  }
+
+  return (
+    <Layout>
+      <Routes>
+        <Route path="/" element={<Overview />} />
+        <Route path="/transactions" element={<Transactions />} />
+        <Route path="/accounts" element={<Accounts />} />
+        <Route path="/pots" element={<Pots />} />
+        <Route path="/budgets" element={<Budgets />} />
+        <Route path="/rules" element={<Rules />} />
+        <Route path="/reports" element={<Reports />} />
+        <Route path="/investments" element={<Investments />} />
+        <Route path="/imports" element={<Imports />} />
+        <Route path="/settings" element={<Settings />} />
+        <Route path="/help" element={<Help />} />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    </Layout>
+  );
+};
+
+const App = () => (
+  <AuthProvider>
+    <AppShell />
+  </AuthProvider>
+);
+
+export default App;

--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -1,0 +1,66 @@
+import { createContext, ReactNode, useContext, useMemo, useState } from 'react';
+
+type AuthContextValue = {
+  isAuthenticated: boolean;
+  login: (username: string, password: string) => Promise<void>;
+  logout: () => void;
+  isLoading: boolean;
+  error: string | null;
+};
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+const STORAGE_KEY = 'sleekfinance.authenticated';
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    return window.sessionStorage.getItem(STORAGE_KEY) === 'true';
+  });
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const login = async (username: string, password: string) => {
+    setIsLoading(true);
+    setError(null);
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    if (!username.trim() || !password.trim()) {
+      setError('Please enter both email and password to continue.');
+      setIsLoading(false);
+      setIsAuthenticated(false);
+      if (typeof window !== 'undefined') {
+        window.sessionStorage.removeItem(STORAGE_KEY);
+      }
+      return;
+    }
+
+    setIsAuthenticated(true);
+    if (typeof window !== 'undefined') {
+      window.sessionStorage.setItem(STORAGE_KEY, 'true');
+    }
+    setIsLoading(false);
+  };
+
+  const logout = () => {
+    setIsAuthenticated(false);
+    if (typeof window !== 'undefined') {
+      window.sessionStorage.removeItem(STORAGE_KEY);
+    }
+  };
+
+  const value = useMemo(
+    () => ({ isAuthenticated, login, logout, isLoading, error }),
+    [isAuthenticated, isLoading, error]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,0 +1,63 @@
+import { NavLink } from 'react-router-dom';
+import { ReactNode } from 'react';
+import { useAuth } from '../auth/AuthContext';
+import Tooltip from './Tooltip';
+import '../styles/layout.css';
+
+const navItems = [
+  { to: '/', label: 'Overview' },
+  { to: '/transactions', label: 'Transactions' },
+  { to: '/accounts', label: 'Accounts' },
+  { to: '/pots', label: 'Pots' },
+  { to: '/budgets', label: 'Budgets' },
+  { to: '/rules', label: 'Rules' },
+  { to: '/reports', label: 'Reports' },
+  { to: '/investments', label: 'Investments' },
+  { to: '/imports', label: 'Imports' },
+  { to: '/settings', label: 'Settings' },
+  { to: '/help', label: 'Help' }
+];
+
+const Layout = ({ children }: { children: ReactNode }) => {
+  const { logout } = useAuth();
+
+  return (
+    <div className="app-shell">
+      <aside className="sidebar" aria-label="Primary">
+        <div className="brand">
+          <span className="brand-mark" aria-hidden>£</span>
+          <span className="brand-name">SleekFinance</span>
+        </div>
+        <nav>
+          <ul className="nav-list">
+            {navItems.map((item) => (
+              <li key={item.to}>
+                <NavLink
+                  to={item.to}
+                  className={({ isActive }) =>
+                    `nav-link ${isActive ? 'nav-link-active' : ''}`
+                  }
+                  end={item.to === '/'}
+                >
+                  <span>{item.label}</span>
+                  <Tooltip label={`${item.label} tooltip placeholder`} />
+                </NavLink>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </aside>
+      <main className="main" role="main">
+        <header className="main-header">
+          <h1 className="sr-only">SleekFinance App Shell</h1>
+          <button type="button" className="logout-button" onClick={logout}>
+            Sign out
+          </button>
+        </header>
+        <div className="content-area">{children}</div>
+      </main>
+    </div>
+  );
+};
+
+export default Layout;

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,0 +1,20 @@
+import Tooltip from './Tooltip';
+import '../styles/page-header.css';
+
+type PageHeaderProps = {
+  title: string;
+  description?: string;
+  tooltip?: string;
+};
+
+const PageHeader = ({ title, description, tooltip }: PageHeaderProps) => (
+  <header className="page-header">
+    <div>
+      <h2>{title}</h2>
+      {description ? <p>{description}</p> : null}
+    </div>
+    <Tooltip label={tooltip ?? `${title} tooltip placeholder`} />
+  </header>
+);
+
+export default PageHeader;

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,0 +1,13 @@
+import '../styles/tooltip.css';
+
+type TooltipProps = {
+  label: string;
+};
+
+const Tooltip = ({ label }: TooltipProps) => (
+  <span className="tooltip" role="img" aria-label={label} title={label}>
+    ⓘ
+  </span>
+);
+
+export default Tooltip;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,76 @@
+:root {
+  color-scheme: dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #121317;
+  color: #f8f8f8;
+  --accent: #ffb347;
+  --accent-strong: #ffcc33;
+  --surface: #1c1f26;
+  --surface-elevated: #242832;
+  --border: rgba(255, 255, 255, 0.08);
+  --text-muted: rgba(255, 255, 255, 0.72);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #121317;
+  color: inherit;
+}
+
+a {
+  color: inherit;
+}
+
+button {
+  font: inherit;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.content-card {
+  background: var(--surface-elevated);
+  border-radius: 16px;
+  padding: 1.5rem;
+  border: 1px solid var(--border);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+}
+
+.placeholder-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.placeholder-tile {
+  background: var(--surface);
+  border-radius: 12px;
+  padding: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  min-height: 120px;
+}
+
+.placeholder-tile h3 {
+  margin-top: 0;
+  font-size: 1rem;
+  color: var(--accent-strong);
+}
+
+.placeholder-tile p {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -1,0 +1,31 @@
+import PageHeader from '../components/PageHeader';
+import Tooltip from '../components/Tooltip';
+
+const Accounts = () => (
+  <div>
+    <PageHeader
+      title="Accounts"
+      description="Create institutions, group holdings, and keep balances synced across every location."
+    />
+    <div className="content-card">
+      <p>
+        You will be able to manage account metadata, reconciliation status, ownership, and reporting
+        currency from this screen.
+      </p>
+      <div className="placeholder-grid">
+        <div className="placeholder-tile">
+          <h3>Account Directory</h3>
+          <p>Placeholder for grouped accounts by institution, including cash, savings, and credit.</p>
+          <Tooltip label="Account directory tooltip placeholder" />
+        </div>
+        <div className="placeholder-tile">
+          <h3>Balance Health</h3>
+          <p>Placeholder for highlighting low balances, stale updates, and reconciliation gaps.</p>
+          <Tooltip label="Balance health tooltip placeholder" />
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default Accounts;

--- a/src/pages/Budgets.tsx
+++ b/src/pages/Budgets.tsx
@@ -1,0 +1,31 @@
+import PageHeader from '../components/PageHeader';
+import Tooltip from '../components/Tooltip';
+
+const Budgets = () => (
+  <div>
+    <PageHeader
+      title="Budgets"
+      description="Plan by month, quarter, or UK fiscal year and monitor progress with rollovers and alerts."
+    />
+    <div className="content-card">
+      <p>
+        Configure envelopes, assign allocation rules, and understand spending drift over time using
+        the budgeting engine to come.
+      </p>
+      <div className="placeholder-grid">
+        <div className="placeholder-tile">
+          <h3>Period Planner</h3>
+          <p>Placeholder for selecting cadence, fiscal-year boundaries, and scenario comparisons.</p>
+          <Tooltip label="Period planner tooltip placeholder" />
+        </div>
+        <div className="placeholder-tile">
+          <h3>Budget Rollovers</h3>
+          <p>Placeholder for tracking carry-over amounts and forecasting end-of-period balances.</p>
+          <Tooltip label="Budget rollovers tooltip placeholder" />
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default Budgets;

--- a/src/pages/Help.tsx
+++ b/src/pages/Help.tsx
@@ -1,0 +1,89 @@
+import PageHeader from '../components/PageHeader';
+import Tooltip from '../components/Tooltip';
+
+const sections = [
+  {
+    title: 'Overview',
+    description:
+      'Snapshots of balances, KPIs, notifications, and recent performance across all pots and accounts.'
+  },
+  {
+    title: 'Transactions',
+    description:
+      'Ledger workspace for categorising, splitting, bulk editing, and reconciling every money movement.'
+  },
+  {
+    title: 'Accounts',
+    description:
+      'Manage institutions, account ownership, connection health, and reconciliation status.'
+  },
+  {
+    title: 'Pots',
+    description:
+      'Group accounts for reporting, toggle inclusion in totals, and define goal allocations.'
+  },
+  {
+    title: 'Budgets',
+    description:
+      'Plan spending and saving by period, monitor rollover balances, and align with fiscal years.'
+  },
+  {
+    title: 'Rules',
+    description:
+      'Automate transaction categorisation, tags, transfer detection, and pot overrides.'
+  },
+  {
+    title: 'Reports',
+    description:
+      'Generate net worth, category trends, allocation audits, and tax-ready statements.'
+  },
+  {
+    title: 'Investments',
+    description:
+      'Track holdings, sector exposure, ISA allowances, dividends, and realised performance.'
+  },
+  {
+    title: 'Imports',
+    description:
+      'Load data from CSV, OFX, QIF, and custom templates with saved mapping profiles and de-duplication.'
+  },
+  {
+    title: 'Settings',
+    description:
+      'Control workspace preferences, notification policies, access, and future integrations.'
+  },
+  {
+    title: 'Help',
+    description: 'Read documentation, onboarding guides, and contact support resources.'
+  }
+];
+
+const Help = () => (
+  <div>
+    <PageHeader
+      title="Help"
+      description="Learn what each section delivers and how SleekFinance keeps your finances organised."
+    />
+    <div className="content-card">
+      <p>
+        Use this guide to understand where to manage specific workflows. Tooltips across the product
+        will eventually surface contextual help and shortcuts.
+      </p>
+      <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+        {sections.map((section) => (
+          <li key={section.title} style={{ marginBottom: '1.25rem' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+              <div>
+                <h3 style={{ margin: 0, color: 'var(--accent-strong)' }}>{section.title}</h3>
+                <p style={{ margin: '0.35rem 0 0', color: 'var(--text-muted)' }}>{section.description}</p>
+              </div>
+              <Tooltip label={`${section.title} help tooltip placeholder`} />
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </div>
+);
+
+export default Help;

--- a/src/pages/Imports.tsx
+++ b/src/pages/Imports.tsx
@@ -1,0 +1,31 @@
+import PageHeader from '../components/PageHeader';
+import Tooltip from '../components/Tooltip';
+
+const Imports = () => (
+  <div>
+    <PageHeader
+      title="Imports"
+      description="Bring transactions in from CSV, OFX, QIF, or custom templates with smart mapping."
+    />
+    <div className="content-card">
+      <p>
+        Launch the import wizard, save mapping profiles, and catch duplicates before they hit the
+        ledger.
+      </p>
+      <div className="placeholder-grid">
+        <div className="placeholder-tile">
+          <h3>File Mapping Wizard</h3>
+          <p>Placeholder for column matching, sample previews, and validation alerts.</p>
+          <Tooltip label="File mapping tooltip placeholder" />
+        </div>
+        <div className="placeholder-tile">
+          <h3>Profile Library</h3>
+          <p>Placeholder for reusable mapping presets and auto-detection logic.</p>
+          <Tooltip label="Profile library tooltip placeholder" />
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default Imports;

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -1,0 +1,31 @@
+import PageHeader from '../components/PageHeader';
+import Tooltip from '../components/Tooltip';
+
+const Investments = () => (
+  <div>
+    <PageHeader
+      title="Investments"
+      description="Track holdings, ISAs, dividends, and sector exposure with real-time analytics."
+    />
+    <div className="content-card">
+      <p>
+        Monitor equity and fund positions, view blended performance, and keep tabs on realised versus
+        unrealised gains.
+      </p>
+      <div className="placeholder-grid">
+        <div className="placeholder-tile">
+          <h3>Holdings Table</h3>
+          <p>Placeholder for quantities, cost basis, and performance metrics.</p>
+          <Tooltip label="Holdings table tooltip placeholder" />
+        </div>
+        <div className="placeholder-tile">
+          <h3>Sector Allocation</h3>
+          <p>Placeholder for tagging investments and visualising diversification.</p>
+          <Tooltip label="Sector allocation tooltip placeholder" />
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default Investments;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,54 @@
+import { FormEvent, useState } from 'react';
+import { useAuth } from '../auth/AuthContext';
+import Tooltip from '../components/Tooltip';
+import '../styles/login.css';
+
+const Login = () => {
+  const { login, isLoading, error } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    await login(email, password);
+  };
+
+  return (
+    <div className="login-screen">
+      <form className="login-card" onSubmit={handleSubmit} aria-label="Sign in form">
+        <h1>SleekFinance</h1>
+        <p className="login-subtitle">Personal finance analytics in one place.</p>
+        <label htmlFor="email">Email</label>
+        <input
+          id="email"
+          type="email"
+          autoComplete="email"
+          placeholder="you@example.com"
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+          required
+        />
+        <label htmlFor="password">Password</label>
+        <input
+          id="password"
+          type="password"
+          autoComplete="current-password"
+          placeholder="Enter any password"
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+          required
+        />
+        <button type="submit" disabled={isLoading}>
+          {isLoading ? 'Signing in…' : 'Sign in'}
+        </button>
+        {error ? <p className="login-error" role="alert">{error}</p> : null}
+        <p className="login-helper">
+          Demo sign-in accepts any credentials and unlocks the navigation shell.
+          <Tooltip label="Login tooltip placeholder" />
+        </p>
+      </form>
+    </div>
+  );
+};
+
+export default Login;

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -1,0 +1,37 @@
+import PageHeader from '../components/PageHeader';
+import Tooltip from '../components/Tooltip';
+
+const Overview = () => (
+  <div>
+    <PageHeader
+      title="Overview"
+      description="High-level health of your finances with quick KPIs and net worth snapshots."
+    />
+    <div className="content-card">
+      <h3>Welcome to SleekFinance</h3>
+      <p>
+        This dashboard will eventually highlight balances, trends, and urgent alerts across your
+        financial life. Use the navigation to explore each workspace.
+      </p>
+      <div className="placeholder-grid" aria-label="Dashboard preview">
+        <div className="placeholder-tile">
+          <h3>Net Worth Timeline</h3>
+          <p>Chart placeholder describing future monthly performance and blended APR reporting.</p>
+          <Tooltip label="Overview tile tooltip placeholder" />
+        </div>
+        <div className="placeholder-tile">
+          <h3>Budget Progress</h3>
+          <p>Gauge placeholder for summarising your budget allocations and rollovers.</p>
+          <Tooltip label="Budget progress tooltip placeholder" />
+        </div>
+        <div className="placeholder-tile">
+          <h3>Upcoming Notifications</h3>
+          <p>Feed placeholder for upcoming bills, low balances, and stale imports.</p>
+          <Tooltip label="Notifications tooltip placeholder" />
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default Overview;

--- a/src/pages/Pots.tsx
+++ b/src/pages/Pots.tsx
@@ -1,0 +1,31 @@
+import PageHeader from '../components/PageHeader';
+import Tooltip from '../components/Tooltip';
+
+const Pots = () => (
+  <div>
+    <PageHeader
+      title="Pots"
+      description="Group accounts into flexible reporting sections that can be included or excluded from totals."
+    />
+    <div className="content-card">
+      <p>
+        Build virtual envelopes for sinking funds, tax reserves, or investment goals. Pots determine
+        how balances roll into your overview and reports.
+      </p>
+      <div className="placeholder-grid">
+        <div className="placeholder-tile">
+          <h3>Pot Manager</h3>
+          <p>Placeholder for drag-and-drop grouping with pot-level overrides.</p>
+          <Tooltip label="Pot manager tooltip placeholder" />
+        </div>
+        <div className="placeholder-tile">
+          <h3>Inclusion Controls</h3>
+          <p>Placeholder for toggling contributions to overview totals and derived KPIs.</p>
+          <Tooltip label="Inclusion controls tooltip placeholder" />
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default Pots;

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -1,0 +1,31 @@
+import PageHeader from '../components/PageHeader';
+import Tooltip from '../components/Tooltip';
+
+const Reports = () => (
+  <div>
+    <PageHeader
+      title="Reports"
+      description="Generate net worth, income vs expense, merchant trends, and tax-ready summaries."
+    />
+    <div className="content-card">
+      <p>
+        Reports will deliver tailored views for fiscal years, calendar months, pots, categories, and
+        allocation audits with exportable charts.
+      </p>
+      <div className="placeholder-grid">
+        <div className="placeholder-tile">
+          <h3>Report Gallery</h3>
+          <p>Placeholder for selecting dashboards like income vs expense and pot insights.</p>
+          <Tooltip label="Report gallery tooltip placeholder" />
+        </div>
+        <div className="placeholder-tile">
+          <h3>Schedule Builder</h3>
+          <p>Placeholder for scheduling exports and sharing filtered report packs.</p>
+          <Tooltip label="Schedule builder tooltip placeholder" />
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default Reports;

--- a/src/pages/Rules.tsx
+++ b/src/pages/Rules.tsx
@@ -1,0 +1,31 @@
+import PageHeader from '../components/PageHeader';
+import Tooltip from '../components/Tooltip';
+
+const Rules = () => (
+  <div>
+    <PageHeader
+      title="Rules"
+      description="Automate categorisation by matching on descriptions, amounts, accounts, and timing."
+    />
+    <div className="content-card">
+      <p>
+        Build sequential rule sets to tag merchants, mark transfers, override pots, and streamline
+        reconciliation.
+      </p>
+      <div className="placeholder-grid">
+        <div className="placeholder-tile">
+          <h3>Rule Library</h3>
+          <p>Placeholder for viewing priorities, hit rates, and conflict alerts.</p>
+          <Tooltip label="Rule library tooltip placeholder" />
+        </div>
+        <div className="placeholder-tile">
+          <h3>Test Console</h3>
+          <p>Placeholder for running sample transactions through the rule engine.</p>
+          <Tooltip label="Test console tooltip placeholder" />
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default Rules;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,31 @@
+import PageHeader from '../components/PageHeader';
+import Tooltip from '../components/Tooltip';
+
+const Settings = () => (
+  <div>
+    <PageHeader
+      title="Settings"
+      description="Control currency, security, notifications, and integrations for your workspace."
+    />
+    <div className="content-card">
+      <p>
+        Configure two-factor authentication, manage user profiles, connect future data sources, and
+        tailor privacy controls.
+      </p>
+      <div className="placeholder-grid">
+        <div className="placeholder-tile">
+          <h3>Profile & Security</h3>
+          <p>Placeholder for credentials, sign-in devices, and session history.</p>
+          <Tooltip label="Profile security tooltip placeholder" />
+        </div>
+        <div className="placeholder-tile">
+          <h3>Workspace Preferences</h3>
+          <p>Placeholder for currency, time zone, and notification policy controls.</p>
+          <Tooltip label="Workspace preferences tooltip placeholder" />
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default Settings;

--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -1,0 +1,31 @@
+import PageHeader from '../components/PageHeader';
+import Tooltip from '../components/Tooltip';
+
+const Transactions = () => (
+  <div>
+    <PageHeader
+      title="Transactions"
+      description="Review, categorise, split, and bulk edit every money movement with powerful filters."
+    />
+    <div className="content-card">
+      <p>
+        A lightning-fast ledger workspace will live here, featuring search, multi-select, keyboard
+        shortcuts, and smart matching for transfers.
+      </p>
+      <div className="placeholder-grid">
+        <div className="placeholder-tile">
+          <h3>Filter Builder</h3>
+          <p>Placeholder for saved views, column sets, and rule visibility toggles.</p>
+          <Tooltip label="Filter builder tooltip placeholder" />
+        </div>
+        <div className="placeholder-tile">
+          <h3>Import Conflict Queue</h3>
+          <p>Placeholder for resolving duplicates from CSV, OFX, and custom templates.</p>
+          <Tooltip label="Import conflict tooltip placeholder" />
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default Transactions;

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1,0 +1,131 @@
+.app-shell {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  min-height: 100vh;
+  background: radial-gradient(circle at top left, rgba(255, 179, 71, 0.08), transparent 60%),
+    #121317;
+}
+
+.sidebar {
+  background: linear-gradient(180deg, rgba(28, 31, 38, 0.95), rgba(18, 19, 23, 0.98));
+  border-right: 1px solid var(--border);
+  padding: 1.5rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.brand-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #121317;
+  font-weight: 700;
+  font-size: 1.25rem;
+}
+
+.brand-name {
+  font-size: 1.1rem;
+}
+
+.nav-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.nav-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.6rem 0.8rem;
+  color: var(--text-muted);
+  text-decoration: none;
+  border-radius: 10px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.nav-link:hover,
+.nav-link:focus-visible {
+  background: rgba(255, 179, 71, 0.16);
+  color: #fff;
+}
+
+.nav-link-active {
+  background: rgba(255, 179, 71, 0.24);
+  color: #fff;
+  box-shadow: inset 0 0 0 1px rgba(255, 179, 71, 0.35);
+}
+
+.main {
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(180deg, rgba(255, 179, 71, 0.04), rgba(18, 19, 23, 1));
+}
+
+.main-header {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  padding: 1rem 2rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.logout-button {
+  background: rgba(255, 179, 71, 0.15);
+  color: var(--accent-strong);
+  border: 1px solid rgba(255, 179, 71, 0.4);
+  border-radius: 999px;
+  padding: 0.4rem 1rem;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.logout-button:hover,
+.logout-button:focus-visible {
+  background: rgba(255, 179, 71, 0.25);
+  transform: translateY(-1px);
+}
+
+.content-area {
+  flex: 1;
+  padding: 2rem 3rem;
+}
+
+@media (max-width: 960px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: sticky;
+    top: 0;
+    flex-direction: row;
+    overflow-x: auto;
+    padding: 1rem;
+    gap: 1rem;
+  }
+
+  .nav-list {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .nav-link {
+    padding: 0.5rem 0.75rem;
+  }
+}

--- a/src/styles/login.css
+++ b/src/styles/login.css
@@ -1,0 +1,88 @@
+.login-screen {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at center, rgba(255, 179, 71, 0.1), transparent 55%),
+    #121317;
+  padding: 2rem;
+}
+
+.login-card {
+  width: min(420px, 100%);
+  background: var(--surface-elevated);
+  border-radius: 20px;
+  padding: 2.5rem 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.35);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.login-card h1 {
+  margin: 0;
+  font-size: 2rem;
+  color: var(--accent-strong);
+  text-align: center;
+}
+
+.login-subtitle {
+  margin: 0 0 0.5rem;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.login-card label {
+  font-weight: 600;
+  font-size: 0.9rem;
+  margin-top: 0.5rem;
+}
+
+.login-card input {
+  background: var(--surface);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  padding: 0.75rem;
+  color: #fff;
+}
+
+.login-card input:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.login-card button {
+  margin-top: 0.5rem;
+  border: none;
+  border-radius: 12px;
+  padding: 0.75rem;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #121317;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.login-card button:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.login-card button:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+.login-error {
+  margin: 0;
+  color: #ff9f9f;
+  font-size: 0.9rem;
+}
+
+.login-helper {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.5rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}

--- a/src/styles/page-header.css
+++ b/src/styles/page-header.css
@@ -1,0 +1,19 @@
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.page-header h2 {
+  margin: 0;
+  font-size: 1.8rem;
+  color: #fff;
+}
+
+.page-header p {
+  margin: 0.35rem 0 0;
+  color: var(--text-muted);
+  max-width: 60ch;
+}

--- a/src/styles/tooltip.css
+++ b/src/styles/tooltip.css
@@ -1,0 +1,18 @@
+.tooltip {
+  font-size: 0.85rem;
+  color: var(--accent-strong);
+  background: rgba(255, 179, 71, 0.12);
+  border-radius: 50%;
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 0.5rem;
+  border: 1px solid rgba(255, 179, 71, 0.4);
+}
+
+.tooltip:hover,
+.tooltip:focus-visible {
+  background: rgba(255, 179, 71, 0.24);
+}

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ ! -d "node_modules" ]; then
+  echo "Installing dependencies..."
+  npm install
+fi
+
+echo "Starting SleekFinance development server..."
+npm run dev -- --host 0.0.0.0

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: '0.0.0.0'
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React application with authentication guard and dark navigation shell
- add placeholder pages for Overview, Transactions, Accounts, Pots, Budgets, Rules, Reports, Investments, Imports, Settings, and Help with tooltip stubs
- document quickstart instructions and provide a start script that installs dependencies and launches the dev server

## Testing
- Not run (npm registry access is blocked in the execution environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e6d79c8d483289298d0d7ff8aba35)