### PR TITLE
Refactor accounts experience into list-first flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,24 +65,31 @@ combination to sign in.
 
 ## Data Model Overview
 
-### Institutions & Accounts
+### Accounts & Providers
 
-- Institutions own accounts and capture metadata such as type and optional website.
-- Account rules
+- Providers are lightweight labels (e.g., Barclays, Vanguard) used to group accounts and surface
+  import hints. Create them from the Accounts page or directly while adding a new account.
+- The Accounts page now opens with a compact list of every account. Each row shows the provider
+  badge, type, currency, current balance, and quick status icons for hidden or off-net-worth
+  accounts. Selecting a row opens the editor on the right.
+- The editor is split into **Basic** and **Advanced** tabs:
+  - **Basic** – account name, provider, type, currency, opening balance/date, plus toggles for
+    **Show in lists** (archives/unarchives the account) and **Count in Net Worth**.
+  - **Advanced** – manual balance adjustments, account reference, notes, include/exclude group
+    membership, and the archive control.
+- Account rules:
   - Opening balance date cannot be in the future.
-  - Names must be unique within an institution.
-  - Toggle inclusion to control participation in overview totals.
-  - Included accounts may join multiple include-only groups; excluded accounts cannot join any
-    include-only group.
+  - Names must be unique per provider.
+  - Accounts excluded from Net Worth cannot join include-only groups.
 
 Example:
 
 ```
-Institution: Modern Bank (type: bank)
-  ├─ Everyday Checking — included in totals, part of "Day-to-Day"
-  └─ Future Savings — included in totals
-Institution: Global Credit (type: card)
-  └─ Global Rewards Card — excluded from totals, in "Exclude: Credit Cycling"
+Provider: Modern Bank (type: bank)
+  ├─ Everyday Checking — shown in lists, counts toward Net Worth, in "Day-to-Day"
+  └─ Future Savings — shown in lists, counts toward Net Worth
+Provider: Global Credit (type: card)
+  └─ Global Rewards Card — hidden from Net Worth, in "Exclude: Credit Cycling"
 ```
 
 ### Account Groups

--- a/src/index.css
+++ b/src/index.css
@@ -235,6 +235,154 @@ button {
   box-shadow: 0 0 0 1px var(--accent);
 }
 
+.accounts-layout {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: minmax(260px, 320px) 1fr;
+  align-items: start;
+}
+
+.accounts-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.accounts-list__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.accounts-list__items {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.account-list-item {
+  display: flex;
+  width: 100%;
+  text-align: left;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.75rem 0.85rem;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.02);
+  color: inherit;
+}
+
+.account-list-item:hover,
+.account-list-item:focus-visible {
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.account-list-item.selected {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
+}
+
+.account-list-item__top {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.account-list-item__name {
+  font-weight: 600;
+}
+
+.account-list-item__meta {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.account-status-icons {
+  display: flex;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+}
+
+.provider-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.18);
+  color: rgba(191, 219, 254, 1);
+}
+
+.accounts-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.account-editor {
+  background: var(--surface);
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.account-editor__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.account-editor__tabs {
+  display: inline-flex;
+  background: rgba(148, 163, 184, 0.15);
+  padding: 0.25rem;
+  border-radius: 999px;
+  gap: 0.25rem;
+}
+
+.account-editor__tabs button {
+  border-radius: 999px;
+  padding: 0.25rem 0.9rem;
+  background: transparent;
+  color: inherit;
+}
+
+.account-editor__tabs button.active {
+  background: var(--accent);
+  color: #111827;
+}
+
+.toggle-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.toggle-row:last-of-type {
+  border-bottom: none;
+}
+
+@media (max-width: 960px) {
+  .accounts-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .accounts-list__actions {
+    justify-content: flex-start;
+  }
+}
+
 .account-card header {
   display: flex;
   flex-wrap: wrap;

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -3,7 +3,25 @@ import PageHeader from '../components/PageHeader';
 import Tooltip from '../components/Tooltip';
 import { useData } from '../data/DataContext';
 import { Account, AccountGroup, DataActionError, Institution } from '../data/models';
-import { formatCurrency, formatDate } from '../utils/format';
+import { formatCurrency } from '../utils/format';
+
+const ACCOUNT_TYPE_OPTIONS: { label: string; value: Account['type'] }[] = [
+  { label: 'Current', value: 'checking' },
+  { label: 'Savings', value: 'savings' },
+  { label: 'Credit card', value: 'credit' },
+  { label: 'ISA / Brokerage', value: 'investment' },
+  { label: 'Cash', value: 'cash' },
+  { label: 'Loan', value: 'loan' }
+];
+
+const TYPE_LABEL: Record<Account['type'], string> = {
+  checking: 'Current',
+  savings: 'Savings',
+  credit: 'Credit card',
+  loan: 'Loan',
+  investment: 'ISA / Brokerage',
+  cash: 'Cash'
+};
 
 const renderError = (error: DataActionError | null) =>
   error ? (
@@ -12,551 +30,389 @@ const renderError = (error: DataActionError | null) =>
     </p>
   ) : null;
 
-type AccountRowProps = {
+type AccountListItemProps = {
   account: Account;
+  provider?: Institution;
+  isSelected: boolean;
+  onSelect: () => void;
+};
+
+const AccountListItem = ({ account, provider, isSelected, onSelect }: AccountListItemProps) => {
+  return (
+    <button
+      type="button"
+      className={`account-list-item${isSelected ? ' selected' : ''}`}
+      onClick={onSelect}
+    >
+      <div className="account-list-item__top">
+        <div>
+          <p className="account-list-item__name">{account.name}</p>
+          <div className="account-list-item__meta">
+            <span className="provider-pill">{provider ? provider.name : 'No provider'}</span>
+            <span>{TYPE_LABEL[account.type] ?? account.type}</span>
+            <span>{account.currency}</span>
+            <span>{formatCurrency(account.currentBalance, account.currency)}</span>
+          </div>
+        </div>
+        <div className="account-status-icons" aria-hidden="true">
+          {account.archived && <span title="Hidden from lists">🙈</span>}
+          {!account.includeInTotals && <span title="Excluded from net worth">∅</span>}
+        </div>
+      </div>
+    </button>
+  );
+};
+
+type AccountEditorProps = {
+  account: Account;
+  providers: Institution[];
   includeGroups: AccountGroup[];
   excludeGroups: AccountGroup[];
+  activeTab: 'basic' | 'advanced';
+  onTabChange: (tab: 'basic' | 'advanced') => void;
+  onArchive: () => void;
+  onRestore: () => void;
 };
 
-const AccountRow = ({ account, includeGroups, excludeGroups }: AccountRowProps) => {
-  const { updateAccount, archiveAccount, setAccountInclusion, updateAccountGroupsForAccount } = useData();
-  const [name, setName] = useState(account.name);
-  const [notes, setNotes] = useState(account.notes ?? '');
-  const [currentBalance, setCurrentBalance] = useState(account.currentBalance.toString());
-  const [currency, setCurrency] = useState(account.currency);
-  const [error, setError] = useState<DataActionError | null>(null);
-  const [saving, setSaving] = useState(false);
+const AccountEditor = ({
+  account,
+  providers,
+  includeGroups,
+  excludeGroups,
+  activeTab,
+  onTabChange,
+  onArchive,
+  onRestore
+}: AccountEditorProps) => {
+  const { updateAccount, setAccountInclusion, updateAccountGroupsForAccount } = useData();
+  const providerOptions = useMemo(
+    () => providers.slice().sort((a, b) => a.name.localeCompare(b.name)),
+    [providers]
+  );
+  const [basicForm, setBasicForm] = useState({
+    name: account.name,
+    institutionId: account.institutionId,
+    type: account.type,
+    currency: account.currency,
+    openingBalance: account.openingBalance.toString(),
+    openingBalanceDate: account.openingBalanceDate.slice(0, 10)
+  });
+  const [advancedForm, setAdvancedForm] = useState({
+    currentBalance: account.currentBalance.toString(),
+    accountNumber: account.accountNumber ?? '',
+    notes: account.notes ?? ''
+  });
+  const [basicError, setBasicError] = useState<DataActionError | null>(null);
+  const [advancedError, setAdvancedError] = useState<DataActionError | null>(null);
 
   useEffect(() => {
-    setName(account.name);
-    setNotes(account.notes ?? '');
-    setCurrentBalance(account.currentBalance.toString());
-    setCurrency(account.currency);
-  }, [account.id, account.name, account.notes, account.currentBalance, account.currency]);
-
-  const handleSave = () => {
-    setSaving(true);
-    const numericBalance = Number.parseFloat(currentBalance);
-    const result = updateAccount(account.id, {
-      name,
-      notes,
-      currentBalance: Number.isNaN(numericBalance) ? account.currentBalance : numericBalance,
-      includeOnlyGroupIds: account.includeOnlyGroupIds,
-      excludeGroupId: account.excludeGroupId,
-      includeInTotals: account.includeInTotals,
-      currency
+    setBasicForm({
+      name: account.name,
+      institutionId: account.institutionId,
+      type: account.type,
+      currency: account.currency,
+      openingBalance: account.openingBalance.toString(),
+      openingBalanceDate: account.openingBalanceDate.slice(0, 10)
     });
-    setSaving(false);
-    setError(result);
+    setAdvancedForm({
+      currentBalance: account.currentBalance.toString(),
+      accountNumber: account.accountNumber ?? '',
+      notes: account.notes ?? ''
+    });
+    setBasicError(null);
+    setAdvancedError(null);
+  }, [account]);
+
+  const handleBasicSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const parsedOpeningBalance = Number.parseFloat(basicForm.openingBalance || '0');
+    const result = updateAccount(account.id, {
+      name: basicForm.name,
+      institutionId: basicForm.institutionId,
+      type: basicForm.type,
+      currency: basicForm.currency.trim().toUpperCase(),
+      openingBalance: Number.isNaN(parsedOpeningBalance)
+        ? account.openingBalance
+        : parsedOpeningBalance,
+      openingBalanceDate: basicForm.openingBalanceDate
+    });
+    setBasicError(result);
   };
 
-  const handleInclusionToggle = (mode: 'included' | 'excluded') => {
-    const result = setAccountInclusion(account.id, mode);
-    setError(result);
+  const handleNetWorthToggle = (checked: boolean) => {
+    const result = setAccountInclusion(account.id, checked ? 'included' : 'excluded');
+    setBasicError(result);
   };
 
-  const handleGroupMembership = (groupIds: string[], excludeGroupId: string | null) => {
-    const result = updateAccountGroupsForAccount(account.id, groupIds, excludeGroupId);
-    setError(result);
-  };
-
-  const handleArchive = () => {
-    if (window.confirm(`Archive ${account.name}? This hides the account but keeps history.`)) {
-      archiveAccount(account.id);
+  const handleShowInListsToggle = (checked: boolean) => {
+    if (checked) {
+      onRestore();
+    } else {
+      onArchive();
     }
   };
 
+  const handleArchiveClick = () => {
+    if (window.confirm(`Archive ${account.name}? This hides the account but keeps history.`)) {
+      onArchive();
+    }
+  };
+
+  const handleAdvancedSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const parsedBalance = Number.parseFloat(advancedForm.currentBalance || '0');
+    const result = updateAccount(account.id, {
+      currentBalance: Number.isNaN(parsedBalance) ? account.currentBalance : parsedBalance,
+      accountNumber: advancedForm.accountNumber.trim() ? advancedForm.accountNumber.trim() : undefined,
+      notes: advancedForm.notes ? advancedForm.notes : undefined
+    });
+    setAdvancedError(result);
+  };
+
+  const handleIncludeGroupChange = (groupIds: string[]) => {
+    const result = updateAccountGroupsForAccount(account.id, groupIds, account.excludeGroupId);
+    setAdvancedError(result);
+  };
+
+  const handleExcludeGroupChange = (groupId: string | null) => {
+    const result = updateAccountGroupsForAccount(account.id, account.includeOnlyGroupIds, groupId);
+    setAdvancedError(result);
+  };
+
   return (
-    <div className="account-card">
-      <header>
-        <div>
-          <h4>{name}</h4>
-          <p className="muted-text">
-            {account.type.toUpperCase()} • {account.currency} • Opening balance{' '}
-            {formatCurrency(account.openingBalance, account.currency)} on {formatDate(account.openingBalanceDate)}
-          </p>
-        </div>
-        <div className="chip-list">
-          <span className={`badge ${account.includeInTotals ? 'included' : 'excluded'}`}>
-            {account.includeInTotals ? 'Included in totals' : 'Excluded from totals'}
-          </span>
-          {account.archived && <span className="badge archived">Archived</span>}
+    <div className="account-editor">
+      <header className="account-editor__header">
+        <h3>{account.name}</h3>
+        <div className="account-editor__tabs" role="tablist">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={activeTab === 'basic'}
+            className={activeTab === 'basic' ? 'active' : ''}
+            onClick={() => onTabChange('basic')}
+          >
+            Basic
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={activeTab === 'advanced'}
+            className={activeTab === 'advanced' ? 'active' : ''}
+            onClick={() => onTabChange('advanced')}
+          >
+            Advanced
+          </button>
         </div>
       </header>
-      <div className="form-grid two-column">
-        <div className="field">
-          <label htmlFor={`name-${account.id}`}>
-            Account name
-            <Tooltip label="Rename the account as it should appear on dashboards." />
-          </label>
-          <input
-            id={`name-${account.id}`}
-            value={name}
-            onChange={(event) => setName(event.target.value)}
-            onBlur={handleSave}
-            placeholder="e.g. Everyday Checking"
-          />
-        </div>
-        <div className="field">
-          <label htmlFor={`currency-${account.id}`}>
-            Currency
-            <Tooltip label="Native currency for this account. Imports default to this unless overridden by a file column." />
-          </label>
-          <input
-            id={`currency-${account.id}`}
-            value={currency}
-            onChange={(event) => setCurrency(event.target.value.toUpperCase())}
-            onBlur={handleSave}
-            placeholder="GBP"
-            maxLength={3}
-            style={{ textTransform: 'uppercase' }}
-          />
-        </div>
-        <div className="field">
-          <label htmlFor={`balance-${account.id}`}>
-            Current balance
-            <Tooltip label="Manually update the balance for offline reconciliation." />
-          </label>
-          <input
-            id={`balance-${account.id}`}
-            type="number"
-            step="0.01"
-            value={currentBalance}
-            onChange={(event) => setCurrentBalance(event.target.value)}
-            onBlur={handleSave}
-          />
-        </div>
-        <div className="field">
-          <label htmlFor={`notes-${account.id}`}>
-            Notes
-            <Tooltip label="Store reconciliation tips, ownership info, or sync reminders." />
-          </label>
-          <textarea
-            id={`notes-${account.id}`}
-            value={notes}
-            onChange={(event) => setNotes(event.target.value)}
-            onBlur={handleSave}
-            placeholder="Optional context for teammates"
-          />
-        </div>
-        <div className="field">
-          <label htmlFor={`include-${account.id}`}>
-            Totals mode
-            <Tooltip label="Toggle whether the account contributes to Overview totals." />
-          </label>
-          <div className="chip-list" id={`include-${account.id}`}>
-            <button
-              type="button"
-              className={`chip-button ${account.includeInTotals ? 'active' : ''}`}
-              onClick={() => handleInclusionToggle('included')}
-            >
-              Included
-            </button>
-            <button
-              type="button"
-              className={`chip-button ${!account.includeInTotals ? 'active' : ''}`}
-              onClick={() => handleInclusionToggle('excluded')}
-            >
-              Excluded
-            </button>
-          </div>
-        </div>
-      </div>
-      <div className="form-grid">
-        <div className="field">
-          <label htmlFor={`include-groups-${account.id}`}>
-            Include-only groups
-            <Tooltip label="Select all focus groups that should show this account even if totals are filtered." />
-          </label>
-          <select
-            multiple
-            id={`include-groups-${account.id}`}
-            value={account.includeOnlyGroupIds}
-            onChange={(event) =>
-              handleGroupMembership(
-                Array.from(event.target.selectedOptions, (option) => option.value),
-                account.excludeGroupId
-              )
-            }
-          >
-            {includeGroups.map((group) => (
-              <option key={group.id} value={group.id}>
-                {group.name}
-              </option>
-            ))}
-          </select>
-          <p className="muted-text">Hold Ctrl or Cmd to select multiple groups.</p>
-        </div>
-        <div className="field">
-          <label htmlFor={`exclude-group-${account.id}`}>
-            Exclude group
-            <Tooltip label="Move the account into a single exclusion group for dashboards." />
-          </label>
-          <select
-            id={`exclude-group-${account.id}`}
-            value={account.excludeGroupId ?? ''}
-            onChange={(event) =>
-              handleGroupMembership(
-                account.includeOnlyGroupIds,
-                event.target.value ? event.target.value : null
-              )
-            }
-          >
-            <option value="">None</option>
-            {excludeGroups.map((group) => (
-              <option key={group.id} value={group.id}>
-                {group.name}
-              </option>
-            ))}
-          </select>
-        </div>
-      </div>
-      <div className="chip-list">
-        {account.includeOnlyGroupIds.map((groupId) => {
-          const group = includeGroups.find((item) => item.id === groupId);
-          if (!group) return null;
-          return (
-            <span key={group.id} className="pill pill-muted" style={{ borderColor: group.color }}>
-              {group.name}
-            </span>
-          );
-        })}
-        {account.excludeGroupId && (
-          <span className="pill" style={{ background: 'rgba(220,38,38,0.2)', color: '#fca5a5' }}>
-            Excluded via {excludeGroups.find((g) => g.id === account.excludeGroupId)?.name ?? 'Group'}
-          </span>
-        )}
-      </div>
-      {renderError(error)}
-      <div className="form-actions">
-        <button
-          type="button"
-          className="danger-button"
-          onClick={handleArchive}
-          aria-label={`Archive ${account.name}`}
-        >
-          Archive account
-        </button>
-        {saving && <span className="muted-text">Saving…</span>}
-      </div>
-    </div>
-  );
-};
 
-const Accounts = () => {
-  const {
-    state,
-    createInstitution,
-    createAccount,
-    archiveInstitution
-  } = useData();
-  const institutions = useMemo(
-    () => state.institutions.filter((institution) => !institution.archived),
-    [state.institutions]
-  );
-  const includeGroups = state.accountGroups.filter((group) => group.type === 'include' && !group.archived);
-  const excludeGroups = state.accountGroups.filter((group) => group.type === 'exclude' && !group.archived);
-  const [institutionForm, setInstitutionForm] = useState({ name: '', type: 'bank' as Institution['type'], website: '' });
-  const [institutionError, setInstitutionError] = useState<DataActionError | null>(null);
-  const [accountError, setAccountError] = useState<DataActionError | null>(null);
-  const [accountForm, setAccountForm] = useState(() => ({
-    institutionId: '',
-    name: '',
-    type: 'checking' as Account['type'],
-    currency: state.settings.baseCurrency,
-    openingBalance: '0',
-    openingBalanceDate: new Date().toISOString().slice(0, 10),
-    includeInTotals: true,
-    includeOnlyGroupIds: [] as string[],
-    excludeGroupId: ''
-  }));
-
-  const handleInstitutionSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const result = createInstitution({
-      name: institutionForm.name,
-      type: institutionForm.type,
-      website: institutionForm.website
-    });
-    setInstitutionError(result);
-    if (!result) {
-      setInstitutionForm({ name: '', type: 'bank', website: '' });
-    }
-  };
-
-  const handleAccountSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const includeOnlyGroupIds = accountForm.includeInTotals
-      ? accountForm.includeOnlyGroupIds
-      : [];
-    const result = createAccount({
-      institutionId: accountForm.institutionId,
-      name: accountForm.name,
-      type: accountForm.type,
-      currency: accountForm.currency,
-      openingBalance: Number.parseFloat(accountForm.openingBalance || '0'),
-      openingBalanceDate: accountForm.openingBalanceDate,
-      includeInTotals: accountForm.includeInTotals,
-      includeOnlyGroupIds,
-      excludeGroupId: accountForm.excludeGroupId || null,
-      notes: undefined
-    });
-    setAccountError(result);
-    if (!result) {
-      setAccountForm({
-        institutionId: '',
-        name: '',
-        type: 'checking',
-        currency: state.settings.baseCurrency,
-        openingBalance: '0',
-        openingBalanceDate: new Date().toISOString().slice(0, 10),
-        includeInTotals: true,
-        includeOnlyGroupIds: [],
-        excludeGroupId: ''
-      });
-    }
-  };
-
-  const accountsByInstitution = useMemo(() => {
-    return institutions.map((institution) => ({
-      institution,
-      accounts: state.accounts.filter(
-        (account) => account.institutionId === institution.id && !account.archived
-      )
-    }));
-  }, [institutions, state.accounts]);
-
-  const handleArchiveInstitution = (institution: Institution) => {
-    if (
-      window.confirm(
-        `Archive ${institution.name}? All accounts under this institution will be archived too.`
-      )
-    ) {
-      archiveInstitution(institution.id);
-    }
-  };
-
-  return (
-    <div className="content-stack">
-      <PageHeader
-        title="Accounts"
-        description="Organise institutions, configure inclusion rules, and keep account metadata consistent."
-      />
-      <div className="form-card">
-        <h3>New institution</h3>
-        <form onSubmit={handleInstitutionSubmit} className="form-grid two-column">
+      {activeTab === 'basic' ? (
+        <form className="form-grid" onSubmit={handleBasicSubmit}>
           <div className="field">
-            <label htmlFor="institution-name">
-              Institution name
-              <Tooltip label="The bank, card provider, or brokerage that owns the accounts." />
+            <label htmlFor="account-name">
+              Account name
+              <Tooltip label="Displayed across the workspace." />
             </label>
             <input
-              id="institution-name"
-              value={institutionForm.name}
+              id="account-name"
+              value={basicForm.name}
               onChange={(event) =>
-                setInstitutionForm((current) => ({ ...current, name: event.target.value }))
+                setBasicForm((current) => ({ ...current, name: event.target.value }))
               }
-              placeholder="Modern Bank"
+              required
             />
           </div>
           <div className="field">
-            <label htmlFor="institution-type">
-              Type
-              <Tooltip label="Used to group similar institutions and drive reporting rules." />
+            <label htmlFor="account-provider">
+              Provider
+              <Tooltip label="Select the bank or provider for this account." />
             </label>
             <select
-              id="institution-type"
-              value={institutionForm.type}
+              id="account-provider"
+              value={basicForm.institutionId}
               onChange={(event) =>
-                setInstitutionForm((current) => ({
-                  ...current,
-                  type: event.target.value as Institution['type']
-                }))
-              }
-            >
-              <option value="bank">Bank</option>
-              <option value="card">Card</option>
-              <option value="brokerage">Brokerage</option>
-              <option value="cash">Cash</option>
-              <option value="other">Other</option>
-            </select>
-          </div>
-          <div className="field">
-            <label htmlFor="institution-website">
-              Website
-              <Tooltip label="Optional URL for quick access to statements." />
-            </label>
-            <input
-              id="institution-website"
-              value={institutionForm.website}
-              onChange={(event) =>
-                setInstitutionForm((current) => ({ ...current, website: event.target.value }))
-              }
-              placeholder="https://"
-            />
-          </div>
-          <div className="form-actions">
-            <button type="submit" className="primary-button">
-              Create institution
-            </button>
-          </div>
-          {renderError(institutionError)}
-        </form>
-      </div>
-      <div className="form-card">
-        <h3>New account</h3>
-        <form onSubmit={handleAccountSubmit} className="form-grid two-column">
-          <div className="field">
-            <label htmlFor="account-institution">
-              Institution
-              <Tooltip label="Accounts inherit statement cadence and authentication from the institution." />
-            </label>
-            <select
-              id="account-institution"
-              value={accountForm.institutionId}
-              onChange={(event) =>
-                setAccountForm((current) => ({ ...current, institutionId: event.target.value }))
+                setBasicForm((current) => ({ ...current, institutionId: event.target.value }))
               }
               required
             >
-              <option value="">Select an institution</option>
-              {institutions.map((institution) => (
-                <option key={institution.id} value={institution.id}>
-                  {institution.name}
+              <option value="">Select a provider</option>
+              {providerOptions.map((provider) => (
+                <option key={provider.id} value={provider.id}>
+                  {provider.name}
                 </option>
               ))}
             </select>
           </div>
           <div className="field">
-            <label htmlFor="account-name">
-              Account name
-              <Tooltip label="Friendly name for statements and dashboards." />
-            </label>
-            <input
-              id="account-name"
-              value={accountForm.name}
-              onChange={(event) =>
-                setAccountForm((current) => ({ ...current, name: event.target.value }))
-              }
-              placeholder="Everyday Checking"
-              required
-            />
-          </div>
-          <div className="field">
             <label htmlFor="account-type">
               Account type
-              <Tooltip label="Used to pick icons and default reporting rules." />
+              <Tooltip label="Choose the closest type for this account." />
             </label>
             <select
               id="account-type"
-              value={accountForm.type}
+              value={basicForm.type}
               onChange={(event) =>
-                setAccountForm((current) => ({
+                setBasicForm((current) => ({
                   ...current,
                   type: event.target.value as Account['type']
                 }))
               }
             >
-              <option value="checking">Checking</option>
-              <option value="savings">Savings</option>
-              <option value="credit">Credit</option>
-              <option value="loan">Loan</option>
-              <option value="investment">Investment</option>
-              <option value="cash">Cash</option>
+              {ACCOUNT_TYPE_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
             </select>
           </div>
           <div className="field">
             <label htmlFor="account-currency">
               Currency
-              <Tooltip label="Currency of statements for this account." />
+              <Tooltip label="Native currency for this account." />
             </label>
             <input
               id="account-currency"
-              value={accountForm.currency}
+              value={basicForm.currency}
               onChange={(event) =>
-                setAccountForm((current) => ({
+                setBasicForm((current) => ({
                   ...current,
                   currency: event.target.value.toUpperCase()
                 }))
               }
-              placeholder={state.settings.baseCurrency}
               maxLength={3}
-              style={{ textTransform: 'uppercase' }}
               required
             />
           </div>
           <div className="field">
-            <label htmlFor="account-opening-balance">
+            <label htmlFor="opening-balance">
               Opening balance
-              <Tooltip label="Starting point for reconciliation and performance tracking." />
+              <Tooltip label="Starting balance for reconciliation." />
             </label>
             <input
-              id="account-opening-balance"
-              value={accountForm.openingBalance}
+              id="opening-balance"
+              type="number"
+              value={basicForm.openingBalance}
               onChange={(event) =>
-                setAccountForm((current) => ({
+                setBasicForm((current) => ({
                   ...current,
                   openingBalance: event.target.value
                 }))
               }
-              type="number"
             />
           </div>
           <div className="field">
-            <label htmlFor="account-opening-date">
+            <label htmlFor="opening-date">
               Opening balance date
-              <Tooltip label="Must not be in the future. Used to limit historical reporting." />
+              <Tooltip label="Must not be in the future." />
             </label>
             <input
-              id="account-opening-date"
+              id="opening-date"
               type="date"
-              value={accountForm.openingBalanceDate}
+              value={basicForm.openingBalanceDate}
               onChange={(event) =>
-                setAccountForm((current) => ({
+                setBasicForm((current) => ({
                   ...current,
                   openingBalanceDate: event.target.value
                 }))
               }
             />
           </div>
-          <div className="field">
-            <label htmlFor="account-inclusion">
-              Include in totals
-              <Tooltip label="If disabled the account will be hidden from high-level totals." />
+          <div className="toggle-row">
+            <label htmlFor="show-in-lists">
+              Show in lists
+              <Tooltip label="Hide or reveal this account in pickers without archiving history." />
             </label>
-            <select
-              id="account-inclusion"
-              value={accountForm.includeInTotals ? 'yes' : 'no'}
+            <input
+              id="show-in-lists"
+              type="checkbox"
+              checked={!account.archived}
+              onChange={(event) => handleShowInListsToggle(event.target.checked)}
+            />
+          </div>
+          <div className="toggle-row">
+            <label htmlFor="count-in-net-worth">
+              Count in Net Worth
+              <Tooltip label="Toggle whether this account contributes to overview totals." />
+            </label>
+            <input
+              id="count-in-net-worth"
+              type="checkbox"
+              checked={account.includeInTotals}
+              onChange={(event) => handleNetWorthToggle(event.target.checked)}
+            />
+          </div>
+          <div className="form-actions">
+            <button type="submit" className="primary-button">
+              Save basic details
+            </button>
+          </div>
+          {renderError(basicError)}
+        </form>
+      ) : (
+        <form className="form-grid" onSubmit={handleAdvancedSubmit}>
+          <div className="field">
+            <label htmlFor="current-balance">
+              Current balance
+              <Tooltip label="Manually update for offline reconciliation." />
+            </label>
+            <input
+              id="current-balance"
+              type="number"
+              value={advancedForm.currentBalance}
               onChange={(event) =>
-                setAccountForm((current) => ({
+                setAdvancedForm((current) => ({
                   ...current,
-                  includeInTotals: event.target.value === 'yes',
-                  includeOnlyGroupIds:
-                    event.target.value === 'yes' ? current.includeOnlyGroupIds : [],
-                  excludeGroupId: event.target.value === 'yes' ? current.excludeGroupId : ''
+                  currentBalance: event.target.value
                 }))
               }
-            >
-              <option value="yes">Yes</option>
-              <option value="no">No</option>
-            </select>
+            />
           </div>
           <div className="field">
-            <label htmlFor="account-include-groups">
-              Include-only groups
-              <Tooltip label="Optional chips that surface the account in specific dashboards." />
+            <label htmlFor="account-number">
+              Account reference
+              <Tooltip label="Optional account number or identifier." />
             </label>
-            <select
-              id="account-include-groups"
-              multiple
-              value={accountForm.includeOnlyGroupIds}
+            <input
+              id="account-number"
+              value={advancedForm.accountNumber}
               onChange={(event) =>
-                setAccountForm((current) => ({
+                setAdvancedForm((current) => ({
                   ...current,
-                  includeOnlyGroupIds: Array.from(event.target.selectedOptions, (option) => option.value)
+                  accountNumber: event.target.value
                 }))
               }
-              disabled={!accountForm.includeInTotals}
+            />
+          </div>
+          <div className="field full-width">
+            <label htmlFor="account-notes">
+              Notes
+              <Tooltip label="Store reference notes, statement reminders, or owner details." />
+            </label>
+            <textarea
+              id="account-notes"
+              value={advancedForm.notes}
+              onChange={(event) =>
+                setAdvancedForm((current) => ({
+                  ...current,
+                  notes: event.target.value
+                }))
+              }
+              rows={4}
+            />
+          </div>
+          <div className="field">
+            <label htmlFor="include-groups">
+              Include-only groups
+              <Tooltip label="Collections that always reveal this account when active." />
+            </label>
+            <select
+              id="include-groups"
+              multiple
+              value={account.includeOnlyGroupIds}
+              onChange={(event) =>
+                handleIncludeGroupChange(
+                  Array.from(event.target.selectedOptions, (option) => option.value)
+                )
+              }
             >
               {includeGroups.map((group) => (
                 <option key={group.id} value={group.id}>
@@ -564,21 +420,18 @@ const Accounts = () => {
                 </option>
               ))}
             </select>
-            <p className="muted-text">Hold Ctrl/Cmd to select multiple.</p>
+            <p className="muted-text small">Hold Ctrl/Cmd to select multiple collections.</p>
           </div>
           <div className="field">
-            <label htmlFor="account-exclude-group">
+            <label htmlFor="exclude-group">
               Exclude group
-              <Tooltip label="Optional container to explicitly remove an account from dashboards." />
+              <Tooltip label="Move the account into a single exclude collection." />
             </label>
             <select
-              id="account-exclude-group"
-              value={accountForm.excludeGroupId}
+              id="exclude-group"
+              value={account.excludeGroupId ?? ''}
               onChange={(event) =>
-                setAccountForm((current) => ({
-                  ...current,
-                  excludeGroupId: event.target.value
-                }))
+                handleExcludeGroupChange(event.target.value ? event.target.value : null)
               }
             >
               <option value="">None</option>
@@ -591,47 +444,492 @@ const Accounts = () => {
           </div>
           <div className="form-actions">
             <button type="submit" className="primary-button">
-              Create account
+              Save advanced details
+            </button>
+            <button type="button" className="danger-button" onClick={handleArchiveClick}>
+              Archive account
             </button>
           </div>
-          {renderError(accountError)}
+          {renderError(advancedError)}
         </form>
-      </div>
-      {accountsByInstitution.map(({ institution, accounts }) => (
-        <div key={institution.id} className="content-card">
-          <div className="section-title">
-            <div>
-              <h3>{institution.name}</h3>
+      )}
+    </div>
+  );
+};
+
+type PanelMode = 'view' | 'create-account' | 'create-provider';
+
+const Accounts = () => {
+  const {
+    state,
+    createInstitution,
+    createAccount,
+    archiveAccount,
+    unarchiveAccount
+  } = useData();
+  const providers = useMemo(() => [...state.institutions], [state.institutions]);
+  const activeProviders = useMemo(
+    () => providers.filter((provider) => !provider.archived),
+    [providers]
+  );
+  const includeGroups = useMemo(
+    () => state.accountGroups.filter((group) => group.type === 'include' && !group.archived),
+    [state.accountGroups]
+  );
+  const excludeGroups = useMemo(
+    () => state.accountGroups.filter((group) => group.type === 'exclude' && !group.archived),
+    [state.accountGroups]
+  );
+  const accounts = useMemo(() => [...state.accounts], [state.accounts]);
+
+  const [selectedAccountId, setSelectedAccountId] = useState<string | null>(null);
+  const [panelMode, setPanelMode] = useState<PanelMode>('view');
+  const [activeTab, setActiveTab] = useState<'basic' | 'advanced'>('basic');
+  const [providerForm, setProviderForm] = useState({
+    name: '',
+    type: 'bank' as Institution['type'],
+    website: ''
+  });
+  const [newAccountForm, setNewAccountForm] = useState({
+    institutionId: '',
+    name: '',
+    type: 'checking' as Account['type'],
+    currency: state.settings.baseCurrency,
+    openingBalance: '0',
+    openingBalanceDate: new Date().toISOString().slice(0, 10),
+    includeInTotals: true,
+    includeOnlyGroupIds: [] as string[],
+    excludeGroupId: '',
+    accountNumber: ''
+  });
+  const [providerError, setProviderError] = useState<DataActionError | null>(null);
+  const [newAccountError, setNewAccountError] = useState<DataActionError | null>(null);
+  const [pendingSelection, setPendingSelection] = useState<
+    { name: string; institutionId: string } | null
+  >(null);
+
+  useEffect(() => {
+    if (panelMode !== 'view') return;
+    if (pendingSelection) {
+      const match = accounts.find(
+        (acct) =>
+          acct.institutionId === pendingSelection.institutionId &&
+          acct.name === pendingSelection.name
+      );
+      if (match) {
+        setSelectedAccountId(match.id);
+        setPendingSelection(null);
+        return;
+      }
+    }
+    if (selectedAccountId && accounts.some((acct) => acct.id === selectedAccountId)) {
+      return;
+    }
+    const fallback = accounts.find((acct) => !acct.archived) ?? accounts[0] ?? null;
+    setSelectedAccountId(fallback ? fallback.id : null);
+  }, [accounts, panelMode, pendingSelection, selectedAccountId]);
+
+  const handleSelectAccount = (accountId: string) => {
+    setPanelMode('view');
+    setSelectedAccountId(accountId);
+    setActiveTab('basic');
+  };
+
+  const handleProviderSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const result = createInstitution({
+      name: providerForm.name,
+      type: providerForm.type,
+      website: providerForm.website
+    });
+    setProviderError(result);
+    if (!result) {
+      setProviderForm({ name: '', type: 'bank', website: '' });
+      setPanelMode('view');
+    }
+  };
+
+  const handleNewAccountSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const pendingKey = {
+      name: newAccountForm.name,
+      institutionId: newAccountForm.institutionId
+    };
+    const includeOnlyGroupIds = newAccountForm.includeInTotals
+      ? newAccountForm.includeOnlyGroupIds
+      : [];
+    const result = createAccount({
+      institutionId: newAccountForm.institutionId,
+      name: newAccountForm.name,
+      type: newAccountForm.type,
+      currency: newAccountForm.currency,
+      openingBalance: Number.parseFloat(newAccountForm.openingBalance || '0'),
+      openingBalanceDate: newAccountForm.openingBalanceDate,
+      includeInTotals: newAccountForm.includeInTotals,
+      includeOnlyGroupIds,
+      excludeGroupId: newAccountForm.excludeGroupId || null,
+      accountNumber: newAccountForm.accountNumber || undefined,
+      notes: undefined
+    });
+    setNewAccountError(result);
+    if (!result) {
+      setNewAccountForm({
+        institutionId: '',
+        name: '',
+        type: 'checking',
+        currency: state.settings.baseCurrency,
+        openingBalance: '0',
+        openingBalanceDate: new Date().toISOString().slice(0, 10),
+        includeInTotals: true,
+        includeOnlyGroupIds: [],
+        excludeGroupId: '',
+        accountNumber: ''
+      });
+      setPendingSelection(pendingKey);
+      setPanelMode('view');
+    }
+  };
+
+  const selectedAccount = panelMode === 'view'
+    ? accounts.find((account) => account.id === selectedAccountId) ?? null
+    : null;
+
+  return (
+    <div className="content-stack">
+      <PageHeader
+        title="Accounts"
+        description="Browse all accounts on the left, then adjust settings in the editor tabs."
+      />
+      <div className="accounts-layout">
+        <aside className="accounts-list">
+          <div className="accounts-list__actions">
+            <button type="button" className="secondary-button" onClick={() => setPanelMode('create-account')}>
+              New account
+            </button>
+            <button type="button" className="secondary-button" onClick={() => setPanelMode('create-provider')}>
+              New provider
+            </button>
+          </div>
+          <div className="accounts-list__items">
+            {accounts.length === 0 && (
+              <p className="muted-text">No accounts yet. Create one to get started.</p>
+            )}
+            {accounts
+              .slice()
+              .sort((a, b) => a.name.localeCompare(b.name))
+              .map((account) => (
+                <AccountListItem
+                  key={account.id}
+                  account={account}
+                  provider={providers.find((provider) => provider.id === account.institutionId)}
+                  isSelected={panelMode === 'view' && selectedAccountId === account.id}
+                  onSelect={() => handleSelectAccount(account.id)}
+                />
+              ))}
+          </div>
+        </aside>
+        <section className="accounts-panel">
+          {panelMode === 'create-provider' ? (
+            <div className="form-card">
+              <h3>New provider</h3>
+              <form onSubmit={handleProviderSubmit} className="form-grid two-column">
+                <div className="field">
+                  <label htmlFor="provider-name">
+                    Provider name
+                    <Tooltip label="Bank, card issuer, or brokerage label." />
+                  </label>
+                  <input
+                    id="provider-name"
+                    value={providerForm.name}
+                    onChange={(event) =>
+                      setProviderForm((current) => ({ ...current, name: event.target.value }))
+                    }
+                    required
+                  />
+                </div>
+                <div className="field">
+                  <label htmlFor="provider-type">
+                    Type
+                    <Tooltip label="Used for icon hints and import defaults." />
+                  </label>
+                  <select
+                    id="provider-type"
+                    value={providerForm.type}
+                    onChange={(event) =>
+                      setProviderForm((current) => ({
+                        ...current,
+                        type: event.target.value as Institution['type']
+                      }))
+                    }
+                  >
+                    <option value="bank">Bank</option>
+                    <option value="card">Card</option>
+                    <option value="brokerage">Brokerage</option>
+                    <option value="cash">Cash</option>
+                    <option value="other">Other</option>
+                  </select>
+                </div>
+                <div className="field full-width">
+                  <label htmlFor="provider-website">
+                    Website
+                    <Tooltip label="Optional URL for quick access." />
+                  </label>
+                  <input
+                    id="provider-website"
+                    value={providerForm.website}
+                    onChange={(event) =>
+                      setProviderForm((current) => ({ ...current, website: event.target.value }))
+                    }
+                  />
+                </div>
+                <div className="form-actions">
+                  <button type="submit" className="primary-button">
+                    Create provider
+                  </button>
+                  <button type="button" className="secondary-button" onClick={() => setPanelMode('view')}>
+                    Cancel
+                  </button>
+                </div>
+                {renderError(providerError)}
+              </form>
+            </div>
+          ) : panelMode === 'create-account' ? (
+            <div className="form-card">
+              <h3>New account</h3>
+              <form onSubmit={handleNewAccountSubmit} className="form-grid two-column">
+                <div className="field">
+                  <label htmlFor="new-account-provider">
+                    Provider
+                    <Tooltip label="Choose the provider this account belongs to." />
+                  </label>
+                  <select
+                    id="new-account-provider"
+                    value={newAccountForm.institutionId}
+                    onChange={(event) =>
+                      setNewAccountForm((current) => ({
+                        ...current,
+                        institutionId: event.target.value
+                      }))
+                    }
+                    required
+                  >
+                    <option value="">Select a provider</option>
+                    {activeProviders.map((provider) => (
+                      <option key={provider.id} value={provider.id}>
+                        {provider.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="field">
+                  <label htmlFor="new-account-name">
+                    Account name
+                    <Tooltip label="Friendly name shown across the app." />
+                  </label>
+                  <input
+                    id="new-account-name"
+                    value={newAccountForm.name}
+                    onChange={(event) =>
+                      setNewAccountForm((current) => ({ ...current, name: event.target.value }))
+                    }
+                    required
+                  />
+                </div>
+                <div className="field">
+                  <label htmlFor="new-account-type">
+                    Account type
+                    <Tooltip label="Pick the closest fit." />
+                  </label>
+                  <select
+                    id="new-account-type"
+                    value={newAccountForm.type}
+                    onChange={(event) =>
+                      setNewAccountForm((current) => ({
+                        ...current,
+                        type: event.target.value as Account['type']
+                      }))
+                    }
+                  >
+                    {ACCOUNT_TYPE_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="field">
+                  <label htmlFor="new-account-currency">
+                    Currency
+                    <Tooltip label="Native currency for this account." />
+                  </label>
+                  <input
+                    id="new-account-currency"
+                    value={newAccountForm.currency}
+                    onChange={(event) =>
+                      setNewAccountForm((current) => ({
+                        ...current,
+                        currency: event.target.value.toUpperCase()
+                      }))
+                    }
+                    maxLength={3}
+                    required
+                  />
+                </div>
+                <div className="field">
+                  <label htmlFor="new-account-opening-balance">
+                    Opening balance
+                    <Tooltip label="Starting balance for reconciliation." />
+                  </label>
+                  <input
+                    id="new-account-opening-balance"
+                    value={newAccountForm.openingBalance}
+                    onChange={(event) =>
+                      setNewAccountForm((current) => ({
+                        ...current,
+                        openingBalance: event.target.value
+                      }))
+                    }
+                    type="number"
+                  />
+                </div>
+                <div className="field">
+                  <label htmlFor="new-account-opening-date">
+                    Opening balance date
+                    <Tooltip label="Must not be in the future." />
+                  </label>
+                  <input
+                    id="new-account-opening-date"
+                    type="date"
+                    value={newAccountForm.openingBalanceDate}
+                    onChange={(event) =>
+                      setNewAccountForm((current) => ({
+                        ...current,
+                        openingBalanceDate: event.target.value
+                      }))
+                    }
+                  />
+                </div>
+                <div className="field">
+                  <label htmlFor="new-account-number">
+                    Account reference
+                    <Tooltip label="Optional account number." />
+                  </label>
+                  <input
+                    id="new-account-number"
+                    value={newAccountForm.accountNumber}
+                    onChange={(event) =>
+                      setNewAccountForm((current) => ({
+                        ...current,
+                        accountNumber: event.target.value
+                      }))
+                    }
+                  />
+                </div>
+                <div className="field">
+                  <label htmlFor="new-account-inclusion">
+                    Count in Net Worth
+                    <Tooltip label="Toggle whether this account contributes to overview totals." />
+                  </label>
+                  <select
+                    id="new-account-inclusion"
+                    value={newAccountForm.includeInTotals ? 'yes' : 'no'}
+                    onChange={(event) =>
+                      setNewAccountForm((current) => ({
+                        ...current,
+                        includeInTotals: event.target.value === 'yes',
+                        includeOnlyGroupIds:
+                          event.target.value === 'yes' ? current.includeOnlyGroupIds : [],
+                        excludeGroupId: event.target.value === 'yes' ? current.excludeGroupId : ''
+                      }))
+                    }
+                  >
+                    <option value="yes">Yes</option>
+                    <option value="no">No</option>
+                  </select>
+                </div>
+                <div className="field">
+                  <label htmlFor="new-account-include-groups">
+                    Include-only groups
+                    <Tooltip label="Collections that always reveal the account." />
+                  </label>
+                  <select
+                    id="new-account-include-groups"
+                    multiple
+                    value={newAccountForm.includeOnlyGroupIds}
+                    onChange={(event) =>
+                      setNewAccountForm((current) => ({
+                        ...current,
+                        includeOnlyGroupIds: Array.from(
+                          event.target.selectedOptions,
+                          (option) => option.value
+                        )
+                      }))
+                    }
+                    disabled={!newAccountForm.includeInTotals}
+                  >
+                    {includeGroups.map((group) => (
+                      <option key={group.id} value={group.id}>
+                        {group.name}
+                      </option>
+                    ))}
+                  </select>
+                  <p className="muted-text small">Hold Ctrl/Cmd to select multiple.</p>
+                </div>
+                <div className="field">
+                  <label htmlFor="new-account-exclude-group">
+                    Exclude group
+                    <Tooltip label="Optional collection that hides the account from dashboards." />
+                  </label>
+                  <select
+                    id="new-account-exclude-group"
+                    value={newAccountForm.excludeGroupId}
+                    onChange={(event) =>
+                      setNewAccountForm((current) => ({
+                        ...current,
+                        excludeGroupId: event.target.value
+                      }))
+                    }
+                  >
+                    <option value="">None</option>
+                    {excludeGroups.map((group) => (
+                      <option key={group.id} value={group.id}>
+                        {group.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="form-actions">
+                  <button type="submit" className="primary-button">
+                    Create account
+                  </button>
+                  <button type="button" className="secondary-button" onClick={() => setPanelMode('view')}>
+                    Cancel
+                  </button>
+                </div>
+                {renderError(newAccountError)}
+              </form>
+            </div>
+          ) : selectedAccount ? (
+            <AccountEditor
+              account={selectedAccount}
+              providers={providers}
+              includeGroups={includeGroups}
+              excludeGroups={excludeGroups}
+              activeTab={activeTab}
+              onTabChange={setActiveTab}
+              onArchive={() => archiveAccount(selectedAccount.id)}
+              onRestore={() => unarchiveAccount(selectedAccount.id)}
+            />
+          ) : (
+            <div className="content-card">
+              <h3>Select an account</h3>
               <p className="muted-text">
-                {institution.type.toUpperCase()} • Onboarded {formatDate(institution.createdAt)}
+                Choose an account from the list to edit its settings, or create a new one to begin.
               </p>
             </div>
-            <button
-              type="button"
-              className="secondary-button"
-              onClick={() => handleArchiveInstitution(institution)}
-            >
-              Archive institution
-            </button>
-          </div>
-          {institution.website && (
-            <p className="muted-text">{institution.website}</p>
           )}
-          <div className="account-grid">
-            {accounts.length === 0 && (
-              <p className="muted-text">No active accounts. Archive history remains searchable.</p>
-            )}
-            {accounts.map((account) => (
-              <AccountRow
-                key={account.id}
-                account={account}
-                includeGroups={includeGroups}
-                excludeGroups={excludeGroups}
-              />
-            ))}
-          </div>
-        </div>
-      ))}
+        </section>
+      </div>
     </div>
   );
 };

--- a/src/pages/Help.tsx
+++ b/src/pages/Help.tsx
@@ -5,20 +5,22 @@ const Help = () => (
   <div className="content-stack">
     <PageHeader
       title="Help"
-      description="Guides for managing accounts, groups, categories, and payees with Stage 2 rules."
+      description="Guides for managing accounts, providers, groups, categories, and payees."
     />
     <div className="content-card">
       <h3>Accounts</h3>
       <p className="muted-text">
-        Each account belongs to an institution. Toggle inclusion status to decide if it contributes to
-        overview totals. Accounts can join multiple include-only groups, but only when they are
-        included in totals.
+        Accounts now open from a compact list. Select any row to reveal the editor with Basic and
+        Advanced tabs. Use the Basic tab to rename, change provider, adjust type or currency, and
+        toggle <strong>Show in lists</strong> (archives/unarchives the account) or <strong>Count in
+        Net Worth</strong>. Advanced covers manual balance adjustments, account references, notes,
+        and collection membership.
       </p>
       <div className="help-diagram">
-        <strong>Inclusion decision tree</strong>
-        <pre>{`Account → Include in totals?  ── yes ──> Eligible for include-only groups
-                         └─ no  ──> Cannot join include-only groups`}</pre>
-        <Tooltip label="Accounts excluded from totals are hidden from dashboards unless a filter explicitly includes them." />
+        <strong>Visibility & totals</strong>
+        <pre>{`Show in lists ── off ──> account archived, hidden from selectors
+Count in Net Worth ── off ──> excluded from overview and net-worth totals`}</pre>
+        <Tooltip label="Archived accounts stay searchable in history but disappear from selectors until restored." />
       </div>
     </div>
     <div className="content-card">


### PR DESCRIPTION
## Summary
- replace the account cards with a list-first layout that opens a tabbed editor for each account
- add Show in lists/Count in Net Worth toggles plus advanced fields, restore archived accounts, and update related styles
- refresh README and in-app help text to describe the new provider terminology and editor flow

## Testing
- npm run build *(fails: repo already missing papaparse types and transaction isDemo flag)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910db6d0dbc8328b9638b71e597f25d)